### PR TITLE
管理者側 会員詳細情報ページ追加

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -4,6 +4,7 @@ class Admin::CustomersController < ApplicationController
   end
 
   def show
+    @customer = Customer.find(params[:id])
   end
 
   def edit

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -5,7 +5,7 @@
     </h2>
     <table class="table table-borderless">
       <tr>
-        <th class->会員ID</th>
+        <th>会員ID</th>
         <td><%= @customer.id %></td>
       </tr>
       <tr>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,2 +1,54 @@
-<h1>Admin::Customers#show</h1>
-<p>Find me in app/views/admin/customers/show.html.erb</p>
+<div class="container">
+  <div class="row">
+    <h2 class="mb-3">
+      <%= @customer.last_name + @customer.first_name%>さんの会員詳細
+    </h2>
+    <table class="table table-borderless">
+      <tr>
+        <th class->会員ID</th>
+        <td><%= @customer.id %></td>
+      </tr>
+      <tr>
+        <th>氏名</th>
+        <td><%= @customer.last_name + " " + @customer.first_name %></td>
+      </tr>
+      <tr>
+        <th>フリガナ</th>
+        <td><%= @customer.last_name_kana + " " + @customer.first_name_kana %></td>
+      </tr>
+      <tr>
+        <th>郵便番号</th>
+        <td><%= @customer.postal_code %></td>
+      </tr>
+      <tr>
+        <th>住所</th>
+        <td><%= @customer.address %></td>
+      </tr>
+      <tr>
+        <th>電話番号</th>
+        <td><%= @customer.tel %></td>
+      </tr>
+      <tr>
+        <th>メールアドレス</th>
+        <td><%= @customer.email %></td>
+      </tr>
+      <tr>
+        <th>会員ステータス</th>
+        <td>
+          <% if @customer.is_deleted %>
+            <span class="text-danger">退会</span>
+          <% else %>
+            <span class="text-success">有効</span>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
+        <th></th>
+        <td>
+          <%= link_to "編集する", edit_admin_customer_path(@customer), class:"btn btn-success" %>
+          <%= link_to "注文履歴一覧を見る", admin_root_path(customer_id: @customer.id), class:"btn btn-primary" %>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
管理者側の会員詳細情報ページ追加しました
このページから注文履歴一覧(admin_root_path)に遷移した場合はGetリクエストのパラメーターに会員idを含めるように実装しました。
パラメーターはコントローラーから
`params[:customer_id]`
で受け取れるので管理者側の注文履歴一覧画面実装の際にこのパラメーターが含まれる場合は、その顧客の注文履歴のみ表示するように実装してください。