### PR TITLE
フォームエラーを表示する共通レイアウトを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,10 @@
  *= require_self
  */
  @import "bootstrap";
+
+ .field_with_errors {
+  display: contents;
+  input {
+    @extend .is-invalid;
+  }
+}

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -4,6 +4,7 @@
   </h2>
 
   <%= form_with model: @customer, url: admin_customer_path, local:true do |f| %>
+    <%= render 'shared/form_error', model: @customer %>
     <div class="form-group row">
       <%= f.label :id, "会員ID", class: "form-label col-sm-2" %>
       <div class="col-sm-8">

--- a/app/views/shared/_form_error.html.erb
+++ b/app/views/shared/_form_error.html.erb
@@ -1,0 +1,21 @@
+<%# フォームエラー表示の共通レイアウト %>
+<%# form_withの次の行でこのレイアウトをrenderすれば良い感じにエラー表示します %>
+<%# 引数にformのmodelを指定 %>
+<%# 例： <%= render 'shared/form_error', model: @customer %> %>
+
+
+<% if model.errors.any? %>
+  <div class="alert alert-danger alert-dismissible fade show">
+    <h5 class="alert-heading">
+      <%= pluralize(model.errors.count, "error") %> prohibited this <%= model.class.to_s.downcase %> from being saved:
+    </h5>
+    <ul class="mb-0">
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+<% end %>

--- a/app/views/shared/_form_error.html.erb
+++ b/app/views/shared/_form_error.html.erb
@@ -1,8 +1,6 @@
 <%# フォームエラー表示の共通レイアウト %>
 <%# form_withの次の行でこのレイアウトをrenderすれば良い感じにエラー表示します %>
 <%# 引数にformのmodelを指定 %>
-<%# 例： <%= render 'shared/form_error', model: @customer %> %>
-
 
 <% if model.errors.any? %>
   <div class="alert alert-danger alert-dismissible fade show">


### PR DESCRIPTION
フォームエラーを表示する共通レイアウトを追加しました。
form_withの次の行で呼び出してもらえれば良い感じにエラー表示します！
引数にform_withのmodelと同じものを渡してください。
例：<%= render 'shared/form_error', model: @customer %>
コントローラ側の処理は`admin/customer#update`を参考にしてみてください。

![image](https://user-images.githubusercontent.com/80801851/118575198-db8d3380-b7c0-11eb-8718-3b90779c47c9.png)

'