### PR TITLE
[fix] 管理者ログインページのレイアウトを調整

### DIFF
--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= render "shared/flash_message" %>
   <div class="row">
     <div class="col-sm-10 col-md-8 col-lg-6 mx-auto">
       <h2 class="mb-3">管理者ログイン</h2>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,22 +1,40 @@
 <div class="container">
-  <h2>管理者ログイン</h2>
-  <%= form_with model: @admin, url: admin_session_path do |f| %>
-    <div class="field">
-      <%= f.label :email, "メールアドレス" %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <div class="row">
+    <div class="col-sm-10 col-md-8 col-lg-6 mx-auto">
+      <h2 class="mb-3">管理者ログイン</h2>
+      
+      <%= form_with model: @admin, url: admin_session_path do |f| %>
+        <div class="form-group row">
+          <%= f.label :email, "メールアドレス", class: "col-sm-4 col-form-label" %>
+          <div class="col-sm-8">
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :password, "パスワード", class: "col-sm-4 col-form-label" %>
+          <div class="col-sm-8">
+            <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+          </div>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="form-group row">
+            <div class="col-sm-8 offset-sm-4">
+              <div class="form-check">
+                <%= f.check_box :remember_me, class: "form-check-input" %>
+                <%= f.label :remember_me, class: "form-check-label" %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        
+        <div class="form-group row">
+          <div class="col-sm-8 offset-sm-4 text-right">
+            <%= f.submit "ログイン", class: "btn btn-primary" %>
+          </div>
+        </div>
+      <% end %>
     </div>
-    <div class="field">
-      <%= f.label :password, "パスワード" %><br />
-      <%= f.password_field :password, autocomplete: "current-password" %>
-    </div>
-    <% if devise_mapping.rememberable? %>
-      <div class="field">
-        <%= f.check_box :remember_me %>
-        <%= f.label :remember_me %>
-      </div>
-    <% end %>
-    <div class="actions">
-      <%= f.submit "Log in" %>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>NaganoCake</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,9 @@
+<% flash.each do |message_type, message| %>
+  <% alert_type = message_type == "notice" ? "success" : "danger" %>
+  <div class="alert alert-<%= alert_type %> alert-dismissible fade show" >
+    <%= message %>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+<% end %>


### PR DESCRIPTION
管理者ログインページのレイアウトを調整しました。
ページ上部にフラッシュメッセージを表示できるようにしました。
それに伴ってフラッシュメッセージ用の部分テンプレート`shared/flash_message`を用意しました。
ビューファイルに以下のコードを差し込めば`flash`オブジェクトに入れたメッセージが表示されます。
`<%= render "shared/flash_message" %>`
`flash[:notice]`の場合は緑色で、`flash[:alert]`の場合は赤色で表示されます。
![image](https://user-images.githubusercontent.com/80801851/118752745-9fc89b80-b89e-11eb-8de8-8f19feafadc6.png)
