### PR TITLE
 [fix] 管理者側 注文履歴一覧ページを修正

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -10,10 +10,10 @@ class Admin::HomesController < ApplicationController
   def top
     if params[:customer_id]
       #遷移してきたIDをカスタマーIDに入れて、whereで取得
-      @orders = Order.where(customer_id: params[:customer_id])
+      @orders = Order.where(customer_id: params[:customer_id]).page(params[:page]).per(10)
     else
       #オーダーのデーター全部
-      @orders = Order.all
+      @orders = Order.all.page(params[:page]).per(10)
     end
   end
 end

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= render "shared/flash_message" %>
   <div class="row">
     <h2 class="mb-3">注文履歴一覧</h2>
     

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,31 +1,36 @@
 <div class="container">
   <div class="row">
     <h2 class="mb-3">注文履歴一覧</h2>
-      <table class="table">
-        <thead class="thead-light">
+    
+    <table class="table">
+      <thead class="thead-light">
+        <tr>
+          <th>購入日時</th>
+          <th>購入者</th>
+          <th>注文個数</th>
+          <th>注文ステータス</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @orders.each do |order| %>
           <tr>
-             <th>購入日時</th>
-             <th>購入者</th>
-             <th>注文個数</th>
-             <th>注文ステータス</th>
+            <td>
+              <!--購入日時のリンク先は注文履歴詳細 slash_and_timeは日本-->
+              <%= link_to admin_order_path(order) do %>
+                <%= order.created_at.to_s(:slash_and_time) %>
+              <% end %>
+            </td>
+            <td><%= order.customer.last_name + order.customer.first_name %></td>
+            <td><%= order.order_details.sum(:quantity) %></td>
+            <td><%= order.order_status %></td>
           </tr>
-        </thead>
-          <tbody>
-            <% @orders.each do |order| %>
-              <tr>
-                <!--購入日時のリンク先は注文履歴詳細 slash_and_timeは日本-->
-                <td>
-                  <%= link_to admin_order_path(order) do %>
-                  <%= order.created_at.to_s(:slash_and_time) %>
-                    <% end %>
-                </td>
-                <td><%= order.customer.last_name + order.customer.first_name %></td>
-                <td><%= order.order_details.sum(:quantity) %></td>
-                <td><%= order.order_status %></td>
-              </tr>
-            <% end %>
-          </tbody>
-      </table>
+        <% end %>
+      </tbody>
+    </table>
+
+    <div class="mx-auto">
+      <%= paginate @orders %>
+    </div>
   </div>
 </div>
 

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>


### PR DESCRIPTION
- 注文履歴一覧をkaminariでページ制御するように変更
- kaminariにbootstrapのスタイルを適用するように変更
- 注文履歴一覧ページの上部にフラッシュメッセージを表示するように変更
![image](https://user-images.githubusercontent.com/80801851/118758940-ee7c3280-b8aa-11eb-90ec-d0d2254fba66.png)