### PR TITLE
 [fix] 商品画像にバリデーションを設定しました #24 修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -9,6 +9,7 @@ class Product < ApplicationRecord
 #バリデーションの記述(空でないこと)
   validates :name, presence: true
   validates :price, presence: true
+  validates :image_id, presence: true
   
   # 税込の計算
   def tax_price


### PR DESCRIPTION
issue #24 を修正しました。
Productモデルの`image_id`に`presence: true`のバリデーションを設定することで対応しました。
これで商品名等と同様に商品画像も空欄のときはバリデーションエラーで拾えるようになっています。
![image](https://user-images.githubusercontent.com/80801851/118766342-41f47d80-b8b7-11eb-859b-3da7ce1966af.png)
