### PR TITLE
[add] 管理側の商品詳細、商品編集追加

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -21,9 +21,16 @@ class Admin::ProductsController < ApplicationController
   end
 
   def edit
+    @product = Product.find(params[:id])
   end
 
   def update
+    @product = Product.find(params[:id])
+    if @product.update(product_params)
+      redirect_to admin_product_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -1,0 +1,52 @@
+ <!--部分テンプレートにより、@product ➩ product-->
+  <%= form_with model: [:admin, product], local:true do |f| %>
+  <%= render 'shared/form_error', model: product %>
+    <div class="row">
+      <div class="col-md-8 offset-md-3">
+
+        <div class="form-group form-inline pl-3">
+          <p class="mr-4">商品画像</p>
+          <div class="ml-5"><%= f.attachment_field :image %></div>
+        </div>
+
+        <div class="form-group form-inline">
+        　<p class="mr-4 pr-3">商品名</p>
+          <div class="ml-5"><%= f.text_field :name, placeholder: "商品名を記述して下さい", size: "30" %></div>
+        </div>
+
+        <div class="form-group form-inline">
+        　<p class="mr-4">商品説明</p>
+          <div class="ml-5"><%= f.text_area :introduction, placeholder: "こちらに商品の説明文を記述して下さい", size: "30x5" %></div>
+        </div>
+
+        <div class="form-group form-inline">
+        　<p class="mr-4">ジャンル</p>
+          <div class="ml-5"><%= f.collection_select :genre_id, Genre.all, :id, :name, prompt: "--選択してください--", size: "30" %></div>
+        </div>
+
+        <div class="form-group form-inline">
+        　<p class="mr-4">税抜価格</p>
+          <p class="ml-5"><%= f.text_field :price, placeholder: "商品の税別価格を記述して下さい", size: "30" %> 円</p>
+        </div>
+
+        <div class="form-group form-inline">
+        　<p class="mr-4">販売ステータス</p>
+        　<%= f.radio_button :is_active, :true %>
+        　<%= f.label :is_active, "販売中" %>
+        　<%= f.radio_button :is_active, :false %>
+        　<%= f.label :is_active, "販売停止中" %>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-3 offset-md-6">
+        <% if product.id.nil? %>
+        <%= f.submit '新規登録', class:"btn btn-sm btn-success" %>
+        <% else %>
+        <%= f.submit "  変更を保存  ", class: 'btn btn-light btn-sm' %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -1,2 +1,8 @@
-<h1>Admin::Products#edit</h1>
-<p>Find me in app/views/admin/products/edit.html.erb</p>
+<!--商品編集画面-->
+<div class="container">
+  <div class="row">
+    <h2 class="mb-3">商品編集</h2>
+  </div>
+<!--管理側の商品新規登録画面と商品編集画面をパーシャル-->
+  <%= render 'form', product: @product %>
+</div>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -3,50 +3,6 @@
   <div class="row">
     <h2 class="mb-3">商品新規登録</h2>
   </div>
-
- <%= form_with model: [:admin, @product], local:true do |f| %>
-   <%= render 'shared/form_error', model: @product %>
- <div class="row">
-  <div class="col-md-8 offset-md-3">
-      <div class="form-group form-inline pl-3">
-        <p class="mr-4">商品画像</p>
-        <div class="ml-5"><%= f.attachment_field :image %></div>
-      </div>
-
-      <div class="form-group form-inline">
-      　<p class="mr-4 pr-3">商品名</p>
-        <div class="ml-5"><%= f.text_field :name, placeholder: "商品名を記述して下さい", size: "30" %></div>
-      </div>
-
-      <div class="form-group form-inline">
-      　<p class="mr-4">商品説明</p>
-        <div class="ml-5"><%= f.text_area :introduction, placeholder: "こちらに商品の説明文を記述して下さい", size: "30x5" %></div>
-      </div>
-
-      <div class="form-group form-inline">
-      　<p class="mr-4">ジャンル</p>
-        <div class="ml-5"><%= f.collection_select :genre_id, Genre.all, :id, :name, prompt: "--選択してください--", size: "30" %></div>
-      </div>
-
-      <div class="form-group form-inline">
-      　<p class="mr-4">税抜価格</p>
-        <p class="ml-5"><%= f.text_field :price, placeholder: "商品の税別価格を記述して下さい", size: "30" %> 円</p>
-      </div>
-
-      <div class="form-group form-inline">
-      　<p class="mr-4">販売ステータス</p>
-      　<%= f.radio_button :is_active, :true %>
-      　<%= f.label :is_active, "販売中" %>
-      　<%= f.radio_button :is_active, :false %>
-      　<%= f.label :is_active, "販売停止中" %>
-      </div>
-    </div>
-   </div>
-
-  <div class="row">
-    <div class="col-md-3 offset-md-6">
-      <%= f.submit '新規登録', class:"btn btn-sm btn-success" %>
-    </div>
-  </div>
-  <% end %>
+<!--管理側の商品新規登録画面と商品編集画面をパーシャル-->
+  <%= render 'form', product: @product %>
 </div>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -1,2 +1,45 @@
-<h1>Admin::Products#show</h1>
-<p>Find me in app/views/admin/products/show.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-4">
+      <p class="title">商品詳細</p>
+      <%= attachment_image_tag @product, :image, format: 'jpeg', size: "270x150" %>
+    </div>
+    <div class="col-lg-8">
+      <table class="table table-borderless">
+        <tr>
+          <td style="width:20%">商品名</td>
+          <td><%= @product.name %></td>
+        </tr>
+        <tr>
+          <td>商品説明</td>
+          <td><%= @product.introduction %></td>
+        </tr>
+        <tr>
+          <td>ジャンル</td>
+          <td><%= @product.genre.name %></td>
+        </tr>
+        <tr>
+          <td>税込価格<br>（税抜価格）</td>
+          <td><%= @product.tax_price.to_s(:delimited) %>（<%= @product.price.to_s(:delimited) %>）円</td>
+        </tr>
+        <tr>
+          <td>販売ステータス</td>
+          <td>
+            <% if  @product.is_active == true %>
+              <p>販売中</p>
+            <%else%>
+              <p>販売停止中</p>
+            <% end %>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
+
+    <div class="row">
+      <div class="center-block mx-auto">
+        <%= link_to "　　編集する　　", edit_admin_product_path(@product), class: 'btn btn-light btn-sm' %>
+      </div>
+    </div>
+
+</div>


### PR DESCRIPTION
管理者側の商品詳細と商品編集の機能を追加致しました。
機能追加に伴い、管理側の商品編集画面と商品新規登録のコードを部分テンプレート化いたしました 。

![image](https://user-images.githubusercontent.com/79980351/118776980-8d148d80-b8c3-11eb-805a-791936b55250.png)
![image](https://user-images.githubusercontent.com/79980351/118777034-9998e600-b8c3-11eb-88fe-de22208965ee.png)
