### PR TITLE
[fix] 管理者側 商品一覧ページのレイアウトを調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,8 @@
  *= require_self
  */
  @import "bootstrap";
+ @import "font-awesome-sprockets";
+ @import "font-awesome";
 
  .field_with_errors {
   display: contents;

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ProductsController < ApplicationController
   def index
-    @products = Product.all
+    @products = Product.all.page(params[:page]).per(10)
   end
 
   def new

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -9,35 +9,36 @@
       <% end %>
     </div>
 
-    <table class="table">
-      <thead class="thead-light">
-        <tr>
-          <th>商品ID</th>
-          <th>商品名</th>
-          <th>税別価格</th>
-          <th>ジャンル</th>
-          <th>ステータス</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @products.each do |product| %>
+    <div class="col-12">
+      <table class="table">
+        <thead class="thead-light">
           <tr>
-            <td><%= product.id %></td>
-            <td><%= link_to product.name, admin_product_path(product.id) %></td>
-            <td><%= product.price %></td>
-            <td><%= product.genre.name %></td>
-            <td>
-              <% if product.is_active %>
-                <span class="text-success">販売中</span>
-              <% else %>
-                <span class="text-secondary">販売停止中</span>
-              <% end %>
-            </td>
+            <th>商品ID</th>
+            <th>商品名</th>
+            <th>税別価格</th>
+            <th>ジャンル</th>
+            <th>ステータス</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-
+        </thead>
+        <tbody>
+          <% @products.each do |product| %>
+            <tr>
+              <td><%= product.id %></td>
+              <td><%= link_to product.name, admin_product_path(product.id) %></td>
+              <td><%= product.price %></td>
+              <td><%= product.genre.name %></td>
+              <td>
+                <% if product.is_active %>
+                  <span class="text-success">販売中</span>
+                <% else %>
+                  <span class="text-secondary">販売停止中</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
     <div class="mx-auto">
       <%= paginate @products %>
     </div>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= render "shared/flash_message" %>
   <div class="row pt-2">
     <div class="col-9">
       <h2>商品一覧</h2>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -1,9 +1,14 @@
 <div class="container">
-    <div class="text-right">
-      <h2><%= link_to "商品新規登録",new_admin_product_path, class: "btn btn-primary" %></h2>
+  <div class="row pt-2">
+    <div class="col-9">
+      <h2>商品一覧</h2>
     </div>
-  <div class="row">
-    <h2 class="mb-3">商品一覧</h2>
+    <div class="col-3 text-right">
+      <%= link_to new_admin_product_path, class: "btn btn-info rounded-circle" do %>
+        <i class="fas fa-plus"></i>
+      <% end %>
+    </div>
+
     <table class="table">
       <thead class="thead-light">
         <tr>
@@ -21,16 +26,20 @@
             <td><%= link_to product.name, admin_product_path(product.id) %></td>
             <td><%= product.price %></td>
             <td><%= product.genre.name %></td>
-              <td>
-                <% if product.is_active %>
-                  <span class="text-success">販売中</span>
-                <% else %>
-                  <span class="text-secondary">販売停止中</span>
-                <% end %>
-              </td>
+            <td>
+              <% if product.is_active %>
+                <span class="text-success">販売中</span>
+              <% else %>
+                <span class="text-secondary">販売停止中</span>
+              <% end %>
+            </td>
           </tr>
-   　  　<% end %>
+        <% end %>
       </tbody>
     </table>
+
+    <div class="mx-auto">
+      <%= paginate @products %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
管理者側 商品一覧ページのレイアウトを調整しました。
kaminariを使ってページ制御するように変更しました。
商品追加ボタンをfont-awesomeのプラスアイコンに変更しました。
application.scssにfont-awesomeの読み込み処理が抜けていたので追加しました。
![image](https://user-images.githubusercontent.com/80801851/118797344-75df9b00-b8d7-11eb-932f-0bb6f6f266c3.png)
