### PR TITLE
[fix] 会員一覧ページのレイアウトを調整

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,6 +1,6 @@
 class Admin::CustomersController < ApplicationController
   def index
-    @customers = Customer.all
+    @customers = Customer.all.page(params[:page]).per(10)
   end
 
   def show

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,39 +1,46 @@
 <div class="container">
+  <%= render "shared/flash_message" %>
   <div class="row">
-    <h2 class="mb-3">会員一覧</h2>
-    <table class="table">
-      <thead class="thead-light">
-        <tr>
-          <th>会員ID</th>
-          <th>氏名</th>
-          <th>メールアドレス</th>
-          <th>ステータス</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @customers.each do |customer| %>
+    <div class="col-12">
+      <h2 class="mb-3">会員一覧</h2>
+      <table class="table">
+        <thead class="thead-light">
           <tr>
-            <th>
-              <%= customer.id %>
-            </th>
-            <td>
-              <%= link_to admin_customer_path(customer) do %>
-                <%= customer.last_name + customer.first_name %>
-              <% end %>
-            </td>
-            <td>
-              <%= customer.email %>
-            </td>
-            <td>
-              <% if customer.is_deleted %>
-                <span class="text-danger">退会</span>
-              <% else %>
-                <span class="text-success">有効</span>
-              <% end %>
-            </td>
+            <th>会員ID</th>
+            <th>氏名</th>
+            <th>メールアドレス</th>
+            <th>ステータス</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @customers.each do |customer| %>
+            <tr>
+              <td>
+                <%= customer.id %>
+              </td>
+              <td>
+                <%= link_to admin_customer_path(customer) do %>
+                  <%= customer.last_name + customer.first_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= customer.email %>
+              </td>
+              <td>
+                <% if customer.is_deleted %>
+                  <span class="text-secondary">退会</span>
+                <% else %>
+                  <span class="text-success">有効</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mx-auto">
+      <%= paginate @customers %>
+    </div>
   </div>
 </div>

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,33 +1,35 @@
 <div class="container">
   <%= render "shared/flash_message" %>
   <div class="row">
-    <h2 class="mb-3">注文履歴一覧</h2>
-    
-    <table class="table">
-      <thead class="thead-light">
-        <tr>
-          <th>購入日時</th>
-          <th>購入者</th>
-          <th>注文個数</th>
-          <th>注文ステータス</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @orders.each do |order| %>
+    <div class="col-12">
+      <h2 class="mb-3">注文履歴一覧</h2>
+      
+      <table class="table">
+        <thead class="thead-light">
           <tr>
-            <td>
-              <!--購入日時のリンク先は注文履歴詳細 slash_and_timeは日本-->
-              <%= link_to admin_order_path(order) do %>
-                <%= order.created_at.to_s(:slash_and_time) %>
-              <% end %>
-            </td>
-            <td><%= order.customer.last_name + order.customer.first_name %></td>
-            <td><%= order.order_details.sum(:quantity) %></td>
-            <td><%= order.order_status %></td>
+            <th>購入日時</th>
+            <th>購入者</th>
+            <th>注文個数</th>
+            <th>注文ステータス</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @orders.each do |order| %>
+            <tr>
+              <td>
+                <!--購入日時のリンク先は注文履歴詳細 slash_and_timeは日本-->
+                <%= link_to admin_order_path(order) do %>
+                  <%= order.created_at.to_s(:slash_and_time) %>
+                <% end %>
+              </td>
+              <td><%= order.customer.last_name + order.customer.first_name %></td>
+              <td><%= order.order_details.sum(:quantity) %></td>
+              <td><%= order.order_status %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
 
     <div class="mx-auto">
       <%= paginate @orders %>


### PR DESCRIPTION
会員一覧ページのレイアウトを調整しました。
kaminariでページ制御するように変更しました。
![image](https://user-images.githubusercontent.com/80801851/118805076-792b5480-b8e0-11eb-93a3-2c65e4d49e58.png)
