### PR TITLE
[fix] 注文履歴詳細ページのレイアウトを調整

### DIFF
--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,10 +1,11 @@
 <div class="container">
-  <h2 class="mb-3">
-    注文履歴詳細
-  </h2>
-
+  <%= render "shared/flash_message" %>
   <div class="row">
-    <div class="col-lg-8">
+    <div class="col-lg-9">
+      <h2 class="mb-3">
+        注文履歴詳細
+      </h2>
+
       <table class="table table-borderless">
         <tr>
           <th>購入者</th>
@@ -17,7 +18,7 @@
         <tr>
           <th>注文日</th>
           <td>
-            <%= @order.created_at %>
+            <%= @order.created_at.to_s(:slash_and_time) %>
           </td>
         </tr>
         <tr>
@@ -37,8 +38,8 @@
           <th>注文ステータス</th>
           <td>
             <%= form_with model: [:admin, @order], local:true, class: "form-inline" do |f| %>
-              <%= f.select :order_status, @order.class.order_statuses.keys,  {}, {class: "custom-select mr-2"} %>
-              <%= f.submit "更新", class: "btn btn-success" %>
+              <%= f.select :order_status, @order.class.order_statuses.keys,  {}, {class: "custom-select mb-2 mr-sm-2"} %>
+              <%= f.submit "更新", class: "btn btn-success mb-2" %>
             <% end %>
           </td>
         </tr>
@@ -47,14 +48,14 @@
   </div>
   
   <div class="row align-items-end">
-    <div class="col-lg-8">
+    <div class="col-lg-9">
       <table class="table">
         <thead class="thead-light">
           <tr>
             <th>商品名</th>
-            <th>単価(税込み)</th>
-            <th>数量</th>
-            <th>小計</th>
+            <th class="text-right">単価(税込)</th>
+            <th class="text-right">数量</th>
+            <th class="text-right">小計</th>
             <th>製作ステータス</th>
           </tr>
         </thead>
@@ -62,13 +63,13 @@
           <% @order.order_details.each do |order_detail| %>
             <tr>
               <td><%= order_detail.product.name %></td>
-              <td><%= order_detail.tax_included_price %></td>
-              <td><%= order_detail.quantity %></td>
-              <td><%= order_detail.tax_included_price * order_detail.quantity %></td>
+              <td class="text-right"><%= order_detail.tax_included_price.to_s(:delimited) %></td>
+              <td class="text-right"><%= order_detail.quantity.to_s(:delimited) %></td>
+              <td class="text-right"><%= (order_detail.tax_included_price * order_detail.quantity).to_s(:delimited) %></td>
               <td>
                 <%= form_with model: [:admin, order_detail], local:true, class: "form-inline" do |f| %>
-                  <%= f.select :making_status, order_detail.class.making_statuses.keys,  {}, {class: "custom-select mr-2"} %>
-                  <%= f.submit "更新", class: "btn btn-success" %>
+                  <%= f.select :making_status, order_detail.class.making_statuses.keys,  {}, {class: "custom-select mb-2 mr-sm-2"} %>
+                  <%= f.submit "更新", class: "btn btn-success mb-2" %>
                 <% end %>
               </td>
             </tr>
@@ -77,23 +78,21 @@
       </table>
     </div>
 
-    <div class="col-lg-4">
+    <div class="ml-auto col-sm-6 col-lg-3">
       <table class="table table-borderless">
         <tr>
           <th>商品合計</th>
-          <td><%= (@order.total_price - @order.shipping_fee).to_s(:delimited) %>円</td>
+          <td class="text-right"><%= (@order.total_price - @order.shipping_fee).to_s(:delimited) %> 円</td>
         </tr>
         <tr>
           <th>送料</th>
-          <td><%= @order.shipping_fee.to_s(:delimited) %>円</td>
+          <td class="text-right"><%= @order.shipping_fee.to_s(:delimited) %> 円</td>
         </tr>
         <tr>
           <th>請求金額合計</th>
-          <td><%= @order.total_price.to_s(:delimited) %>円</td>
+          <td class="text-right"><%= @order.total_price.to_s(:delimited) %> 円</td>
         </tr>
       </table>
     </div>
   </div>
-
-
 </div>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -26,7 +26,7 @@
             <tr>
               <td><%= product.id %></td>
               <td><%= link_to product.name, admin_product_path(product.id) %></td>
-              <td><%= product.price %></td>
+              <td><%= product.price.to_s(:delimited) %></td>
               <td><%= product.genre.name %></td>
               <td>
                 <% if product.is_active %>


### PR DESCRIPTION
管理者側 注文履歴詳細ページのレイアウトを調整しました。
金額の表示が3桁区切りになっていないところがあったので修正しました。