### PR TITLE
[add] 注文ステータス、製作ステータスを自動で更新する機能を追加

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,7 +16,7 @@ class Order < ApplicationRecord
 
   # order_statusが「入金待ち」以外に変更されたときに、「着手不可」になっている商品を全て「製作待ち」に変更
   def update_making_status
-    if order_status != "入金待ち"
+    unless order_status == "入金待ち"
       order_details.each do |order_detail|
         if order_detail.making_status == "着手不可"
           order_detail.update(making_status: "製作待ち")

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,4 +5,23 @@ class Order < ApplicationRecord
   enum payment_method: {クレジットカード:0, 銀行振込:1}
   enum order_status: {入金待ち:0, 入金確認:1,  製作中:2, 発送準備中:3, 発送済み:4}
 
+  after_update do
+    if saved_change_to_order_status?
+      # order_statusの値が変更されたときにupdate_making_statusを呼び出し
+      update_making_status
+    end
+  end
+
+  private
+
+  # order_statusが「入金待ち」以外に変更されたときに、「着手不可」になっている商品を全て「製作待ち」に変更
+  def update_making_status
+    if order_status != "入金待ち"
+      order_details.each do |order_detail|
+        if order_detail.making_status == "着手不可"
+          order_detail.update(making_status: "製作待ち")
+        end
+      end
+    end
+  end
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -2,5 +2,37 @@ class OrderDetail < ApplicationRecord
   belongs_to :order
   belongs_to :product
 
-  enum making_status: {制作不可:0, 製作待ち:1,  製作中:2, 製作完了:3}
+  enum making_status: {着手不可:0, 製作待ち:1,  製作中:2, 製作完了:3}
+
+  after_update do
+    if saved_change_to_making_status?
+      # making_statusの値が変更されたときにupdate_order_statusを呼び出し
+      update_order_status
+    end
+  end
+
+  private
+  
+  def update_order_status
+    if making_status == "製作中"
+      # 商品が「製作中」になったら、注文のステータスも「製作中」に変更
+      order.update(order_status: "製作中")
+
+    # 商品が「製作完了」になったら
+    elsif making_status == "製作完了"
+      # すべての注文商品が「製作完了」になっているか判定するフラグ
+      all_finished = true
+      # 紐付いている注文の注文商品すべてに対して実行
+      order.order_details.each do |order_detail|
+        unless order_detail.making_status == "製作完了"
+          # 「製作完了」でない商品があったらフラグをfalseに変更
+          all_finished = false
+        end
+      end
+      if all_finished
+        # すべての注文商品が「製作完了」になったら、紐づく注文のステータスを「発送準備中」に変更
+        order.update(order_status: "発送準備中")
+      end
+    end
+  end
 end


### PR DESCRIPTION
要件定義書の記載通りに注文ステータス、製作ステータスを自動更新する機能を作成しました。
モデルの方に処理を記述したので、すでに実装されているコントローラ側の処理の変更は必要ありません。
製作ステータスの「着手不可」が「制作不可」になっていたので、要件定義書に合わせて「着手不可」に変更させていただきました。
![image](https://user-images.githubusercontent.com/80801851/118917834-acb3c080-b96c-11eb-8d7c-788feefff156.png)
